### PR TITLE
Use char instead of u8 for parser's input to improve error message

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2,13 +2,13 @@ use std::fmt::{Display, Formatter};
 use std::str;
 use std::{fmt::Debug, str::FromStr};
 
-use pom::char_class::{alpha, digit};
+use pom::Error;
 use pom::parser::{end, is_a, one_of, sym, Parser};
 use serde::{de, Deserialize, Deserializer};
 use strum_macros::{AsRefStr, Display, EnumString};
 
 /// Key separator
-const KEY_SEP: u8 = b'-';
+const KEY_SEP: char = '-';
 
 #[derive(Debug, Eq, Hash, PartialEq)]
 pub(crate) struct Node {
@@ -68,9 +68,12 @@ pub(crate) enum Key {
 ///
 /// # Errors
 ///
-/// This function will return an error if .
-pub(crate) fn parse(s: &str) -> Result<Node, pom::Error> {
-    node().parse(s.as_bytes())
+/// This function will return an error if it can't parse the given input.
+pub(crate) fn parse(s: &str) -> Result<Node, Error> {
+    let input = s.chars().collect::<Vec<char>>();
+    let result = node().parse(&input);
+
+    result
 }
 
 // node      = modifiers* key
@@ -78,28 +81,30 @@ pub(crate) fn parse(s: &str) -> Result<Node, pom::Error> {
 // modifier  = "ctrl" | "cmd" | "alt" | "shift"
 // key       = char | "esc" | "del" | "enter" | ...
 // char      = "a..z" | "A..Z" | "0".."9" | ...
-fn node<'a>() -> Parser<'a, u8, Node> {
+fn node<'a>() -> Parser<'a, char, Node> {
     combination() - end()
 }
 
-fn key<'a>() -> Parser<'a, u8, Key> {
+fn key<'a>() -> Parser<'a, char, Key> {
     fn_key() | parse_enum::<Key>() | char()
 }
 
-fn char<'a>() -> Parser<'a, u8, Key> {
-    is_a(|c: u8| c.is_ascii()).map(|c| Key::Char(c.into()))
+fn char<'a>() -> Parser<'a, char, Key> {
+    is_a(ascii).map(Key::Char)
 }
 
 /// Parses F0..F12
-fn fn_key<'a>() -> Parser<'a, u8, Key> {
-    sym(b'f') * ((sym(b'1') * one_of(b"012")).map(|n| 10 + n) | is_a(digit)).map(|n| Key::F(n - 48))
+fn fn_key<'a>() -> Parser<'a, char, Key> {
+    sym('f')
+        * ((sym('1') * one_of("012")).map(|n| 10 + n as u8) | is_a(digit).map(|n| n as u8))
+            .map(|n| Key::F(n - 48))
 }
 
-fn modifier<'a>() -> Parser<'a, u8, Modifier> {
+fn modifier<'a>() -> Parser<'a, char, Modifier> {
     parse_enum::<Modifier>() - sym(KEY_SEP).opt()
 }
 
-fn combination<'a>() -> Parser<'a, u8, Node> {
+fn combination<'a>() -> Parser<'a, char, Node> {
     (modifier().repeat(..4) + key()).map(|(m, key)| {
         let mods = m.into_iter().map(|v| v as u8).sum();
 
@@ -108,13 +113,28 @@ fn combination<'a>() -> Parser<'a, u8, Node> {
 }
 
 /// Parses a string into Enum<T>
-fn parse_enum<'a, T>() -> Parser<'a, u8, T>
+fn parse_enum<'a, T>() -> Parser<'a, char, T>
 where
     T: FromStr + 'static,
     <T as FromStr>::Err: Debug,
 {
     let p = is_a(alpha).repeat(2..);
-    p.convert(|s| std::str::from_utf8(&s).unwrap().parse::<T>())
+    p.convert(|s| s.iter().collect::<String>().parse::<T>())
+}
+
+#[inline]
+fn alpha(term: char) -> bool {
+    term.is_ascii_alphabetic()
+}
+
+#[inline]
+fn ascii(term: char) -> bool {
+    term.is_ascii()
+}
+
+#[inline]
+fn digit(term: char) -> bool {
+    term.is_ascii_digit()
 }
 
 /// Deserializes into Node
@@ -132,7 +152,7 @@ impl Display for Node {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         MODIFIERS.iter().for_each(|m| {
             if self.modifiers & *m as u8 != 0 {
-                write!(f, "{m}{}", KEY_SEP as char).unwrap();
+                write!(f, "{m}{}", KEY_SEP).unwrap();
             }
         });
 
@@ -146,31 +166,76 @@ impl Display for Node {
 
 #[cfg(test)]
 mod tests {
-    use pom::parser::end;
+    use pom::{parser::end, Error};
     use serde::Deserialize;
 
     use crate::parser::{parse_enum, Key, Modifier, Node};
 
-    use super::fn_key;
+    use super::{fn_key, parse};
+
+    #[test]
+    fn test_parse() {
+        let err = |e| Err::<Node, Error>(e);
+
+        [
+            ("alt-f", Ok(Node::new(Modifier::Alt as u8, Key::Char('f')))),
+            ("space", Ok(Node::new(0, Key::Space))),
+            (
+                "delta",
+                err(Error::Mismatch {
+                    message: "expect end of input, found: e".into(),
+                    position: 1,
+                }),
+            ),
+            (
+                "shift-a",
+                Ok(Node::new(Modifier::Shift as u8, Key::Char('a'))),
+            ),
+            (
+                "shift-a-delete",
+                err(Error::Mismatch {
+                    message: "expect end of input, found: -".into(),
+                    position: 7,
+                }),
+            ),
+            (
+                "al",
+                err(Error::Mismatch {
+                    message: "expect end of input, found: l".into(),
+                    position: 1,
+                }),
+            ),
+        ]
+        .map(|(input, result)| {
+            let output = parse(input);
+            assert_eq!(result, output);
+        });
+    }
 
     #[test]
     fn test_parse_fn_key() {
         // Valid number
         (0..=12).for_each(|n| {
-            let input = format!("f{n}");
-            let result = (fn_key() - end()).parse(input.as_bytes());
+            let input = format!("f{n}").chars().collect::<Vec<char>>();
+            let result = (fn_key() - end()).parse(&input);
 
             assert_eq!(Key::F(n), result.unwrap());
         });
 
         // Invalid number
-        assert!((fn_key() - end()).parse(b"f14").is_err());
+        [13, 15].map(|n| {
+            let input: Vec<char> = format!("f{n}").chars().collect();
+            let result = (fn_key() - end()).parse(&input);
+
+            assert!(result.is_err());
+        });
     }
 
     #[test]
     fn test_parse_enum() {
         [("up", Key::Up), ("esc", Key::Esc), ("del", Key::Delete)].map(|(s, key)| {
-            let r = parse_enum::<Key>().parse(s.as_bytes());
+            let input: Vec<char> = s.chars().collect();
+            let r = parse_enum::<Key>().parse(&input);
             assert_eq!(r.unwrap(), key);
         });
     }
@@ -183,15 +248,9 @@ mod tests {
             (Node::new(0, Key::Space), "space"),
             (Node::new(0, Key::Char('g')), "g"),
             (Node::new(0, Key::Char('#')), "#"),
+            (Node::new(Modifier::Alt as u8, Key::Char('f')), "alt-f"),
             (
-                Node::new(Modifier::Alt as u8, Key::Char('f')),
-                "alt-f",
-            ),
-            (
-                Node::new(
-                    Modifier::Shift as u8 | Modifier::Cmd as u8,
-                    Key::Char('f'),
-                ),
+                Node::new(Modifier::Shift as u8 | Modifier::Cmd as u8, Key::Char('f')),
                 "cmd-shift-f",
             ),
         ]
@@ -223,10 +282,7 @@ delete = "d"
 
         [
             Node::new(Modifier::Alt as u8, Key::Char('d')),
-            Node::new(
-                Modifier::Cmd as u8 | Modifier::Shift as u8,
-                Key::Delete,
-            ),
+            Node::new(Modifier::Cmd as u8 | Modifier::Shift as u8, Key::Delete),
             Node::new(0, Key::Delete),
         ]
         .map(|n| {


### PR DESCRIPTION
When using u8. The error message from parser always shows ascii decimal value which is not very clear to the end users.